### PR TITLE
Gamesir all  (Improve joystick controller detection and mappings)

### DIFF
--- a/command/arms_teleop/config/gamesir_two_arm.yaml
+++ b/command/arms_teleop/config/gamesir_two_arm.yaml
@@ -1,5 +1,5 @@
 # 手柄按键和摇杆映射配置
-# 适用于 Sony Interactive Entertainment Wireless Controller（临时沿用 default 配置）
+# 适用于 PS4 Controller / ARM 平台
 
 /**:
   ros__parameters:
@@ -7,40 +7,39 @@
     # Xbox 控制器按键索引:
     # 0=A, 1=B, 2=X, 3=Y, 4=LB, 5=RB, 6=Back, 7=Start, 8=Guide, 9=LS, 10=RS
     button_mapping:
-      a_button: 0          # A 按钮 - 切换目标手臂
-      b_button: 1          # B 按钮 - 发送命令
-      x_button: 3          # X 按钮 - 开关夹爪
-      y_button: 2          # Y 按钮 - 预留
+      a_button: 1          # A 按钮 - 切换目标手臂
+      b_button: 2          # B 按钮 - 发送命令
+      x_button: 0          # X 按钮 - 开关夹爪
+      y_button: 3          # Y 按钮 - 预留
       lb_button: 4         # 左肩键 - 组合键
       rb_button: 5         # 右肩键 - 切换控制模式（ARM/CHASSIS）
       back_button: 8       # Back 按钮 - 切换镜像移动模式
       start_button: 9      # Start 按钮 - 特殊命令
-      left_stick_button: 11 # 左摇杆按下 - 切换高速/低速模式
-      right_stick_button: 12 # 右摇杆按下 - 启用/禁用控制
+      left_stick_button: 10 # 左摇杆按下 - 切换高速/低速模式
+      right_stick_button: 11 # 右摇杆按下 - 启用/禁用控制
 
     # 摇杆和 D-Pad 映射 (Axes Mapping)
-    # Xbox 控制器轴索引:
-    # 0=LS_X, 1=LS_Y, 2=LT, 3=RS_X, 4=RS_Y, 5=RT, 6=DPad_X, 7=DPad_Y
+    # ARM 平台上 PS4 Controller 的右摇杆 Y 轴为 3
     axes_mapping:
       left_stick_x: 0      # 左摇杆 X 轴 - 控制 Y 方向移动
       left_stick_y: 1      # 左摇杆 Y 轴 - 控制 X 方向移动
-      right_stick_x: 3     # 右摇杆 X 轴 - 控制 Yaw 旋转
-      right_stick_y: 4     # 右摇杆 Y 轴 - 控制 Z 方向移动
+      right_stick_x: 2     # 右摇杆 X 轴 - 控制 Yaw 旋转
+      right_stick_y: 3     # 右摇杆 Y 轴 - 控制 Z 方向移动
       dpad_x: 6            # D-Pad X 轴 - 控制 Pitch 旋转
       dpad_y: 7            # D-Pad Y 轴 - 控制 Roll 旋转 如果是底盘模式的话，就是控制腰部升降，1是腰部上升，-1是腰部下降，0是停止
       deadzone: 0.1        # 摇杆死区
       dpad_deadzone: 0.5   # D-Pad 死区
-    
+
     # 镜像移动配置 (Mirror Movement)
     # 当启用时，左摇杆的 X 和 Y 方向都会取反（镜像）
     mirror_movement: true  # 默认开启镜像移动
-    
+
     # 速度模式配置 (Speed Mode)
     # 通过按下左摇杆按钮可以在高速和低速模式之间切换
     speed:
       low_scale: 0.3   # 低速模式缩放因子 (30% 速度)
       high_scale: 1.0  # 高速模式缩放因子 (100% 速度)
-    
+
     # 底盘速度配置 (Chassis Speed)
     # 底盘控制的线速度和角速度缩放因子
     chassis:

--- a/command/arms_teleop/include/arms_teleop/joystick_teleop.h
+++ b/command/arms_teleop/include/arms_teleop/joystick_teleop.h
@@ -24,6 +24,8 @@ private:
     void processAxes(const sensor_msgs::msg::Joy::SharedPtr msg);
     void processChassisAxes(const sensor_msgs::msg::Joy::SharedPtr msg);
     double applyDeadzone(double value, double deadzone = 0.1) const;
+    bool areControlAxesNeutral(const sensor_msgs::msg::Joy::SharedPtr msg) const;
+    void publishZeroCommands();
     void loadButtonMapping();
     void printButtonMapping();
 
@@ -41,6 +43,7 @@ private:
     
     // State management
     bool enabled_;
+    bool waiting_for_neutral_axes_;
     rclcpp::Time lastUpdateTime_;
     
     // Control mode (ARM_MODE or CHASSIS_MODE)

--- a/command/arms_teleop/launch/joystick_teleop.launch.py
+++ b/command/arms_teleop/launch/joystick_teleop.launch.py
@@ -37,6 +37,7 @@ def _find_joystick_aliases(joy_dev):
     resolved_path = _resolve_js_device(joy_dev)
     by_id_dir = '/dev/input/by-id'
     aliases = []
+    joystick_event_aliases = []
 
     if not os.path.isdir(by_id_dir):
         return aliases
@@ -46,10 +47,21 @@ def _find_joystick_aliases(joy_dev):
         try:
             if os.path.realpath(full_path) == resolved_path:
                 aliases.append(entry)
+            elif 'joystick' in entry.lower():
+                joystick_event_aliases.append(entry)
         except OSError:
             continue
 
+    # Some containers expose /dev/input/js* but only provide by-id aliases for
+    # the event joystick node. Use that as a fallback for device-name matching.
+    if not aliases and len(joystick_event_aliases) == 1:
+        aliases.extend(joystick_event_aliases)
+
     return aliases
+
+
+def _normalize_device_name(name):
+    return re.sub(r'[^a-z0-9]+', ' ', name.lower()).strip()
 
 
 def _detect_config_name(config_value, config_dir, joy_dev):
@@ -75,14 +87,20 @@ def _detect_config_name(config_value, config_dir, joy_dev):
     match_sources.extend(_find_joystick_aliases(joy_dev))
 
     device_config_aliases = {
+        'gamesir-dongle': 'gamesir',
+        'gamesir': 'gamesir',
         'sony interactive entertainment wireless controller': 'gamesir_two',
     }
 
     for source in match_sources:
         lowered = source.lower()
+        normalized = _normalize_device_name(source)
         for device_name, config_name in device_config_aliases.items():
             config_path = os.path.join(config_dir, f'{config_name}.yaml')
-            if device_name in lowered and os.path.exists(config_path):
+            if (
+                (device_name in lowered or _normalize_device_name(device_name) in normalized)
+                and os.path.exists(config_path)
+            ):
                 print(f"[INFO] Auto-selected joystick config '{config_name}' for device '{source}'")
                 return config_name
 
@@ -91,7 +109,7 @@ def _detect_config_name(config_value, config_dir, joy_dev):
             key=len,
             reverse=True,
         ):
-            if config_name.lower() in lowered:
+            if config_name.lower() in lowered or _normalize_device_name(config_name) in normalized:
                 print(f"[INFO] Auto-selected joystick config '{config_name}' for device '{source}'")
                 return config_name
 

--- a/command/arms_teleop/launch/joystick_teleop.launch.py
+++ b/command/arms_teleop/launch/joystick_teleop.launch.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
 
 import os
+import platform
 import re
-from ament_index_python.packages import get_package_share_directory
+import subprocess
+from ament_index_python.packages import get_package_prefix, get_package_share_directory
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, OpaqueFunction
 from launch.substitutions import LaunchConfiguration
@@ -18,7 +20,99 @@ def _extract_device_id(joy_dev):
     match = re.search(r'js(\d+)$', resolved_path)
     if match:
         return int(match.group(1))
+    if str(joy_dev).isdigit():
+        return int(joy_dev)
     return 0
+
+
+def _enumerate_joy_devices():
+    try:
+        joy_prefix = get_package_prefix('joy')
+    except Exception:
+        return {}
+
+    executable = os.path.join(joy_prefix, 'lib', 'joy', 'joy_enumerate_devices')
+    if not os.path.exists(executable):
+        return {}
+
+    try:
+        result = subprocess.run(
+            [executable],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=3.0,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return {}
+
+    devices = {}
+    for line in result.stdout.splitlines():
+        match = re.match(
+            r'\s*(\d+)\s*:\s*[^:]+:\s*(?:true|false)\s*:\s*(?:true|false)\s*:\s*(.+?)\s*$',
+            line,
+            re.IGNORECASE,
+        )
+        if match:
+            devices[int(match.group(1))] = match.group(2).strip()
+
+    return devices
+
+
+def _read_joystick_name_from_joy_enumerate(joy_dev):
+    device_id = _extract_device_id(joy_dev)
+    devices = _enumerate_joy_devices()
+    return devices.get(device_id, '')
+
+
+def _list_js_devices():
+    input_dir = '/dev/input'
+    if not os.path.isdir(input_dir):
+        return []
+
+    return sorted(
+        name for name in os.listdir(input_dir)
+        if re.fullmatch(r'js\d+', name)
+    )
+
+
+def _read_input_devices_from_proc():
+    proc_input_path = '/proc/bus/input/devices'
+
+    try:
+        with open(proc_input_path, 'r', encoding='utf-8') as f:
+            blocks = f.read().split('\n\n')
+    except OSError:
+        return []
+
+    devices = []
+    for block in blocks:
+        name = ''
+        handlers = ''
+
+        for line in block.splitlines():
+            if line.startswith('N: Name='):
+                name = line.split('=', 1)[1].strip().strip('"')
+            elif line.startswith('H: Handlers='):
+                handlers = line.split('=', 1)[1].strip()
+
+        if name:
+            devices.append({'name': name, 'handlers': handlers})
+
+    return devices
+
+
+def _read_joystick_name_from_proc(joy_dev):
+    resolved_path = _resolve_js_device(joy_dev)
+    js_name = os.path.basename(resolved_path)
+
+    for device in _read_input_devices_from_proc():
+        name = device['name']
+        handlers = device['handlers']
+        if name and re.search(rf'(^|\s){re.escape(js_name)}($|\s)', handlers):
+            return name
+
+    return ''
 
 
 def _read_joystick_name(joy_dev):
@@ -30,10 +124,10 @@ def _read_joystick_name(joy_dev):
         with open(sysfs_name_path, 'r', encoding='utf-8') as f:
             return f.read().strip()
     except OSError:
-        return ''
+        return _read_joystick_name_from_proc(joy_dev)
 
 
-def _find_joystick_aliases(joy_dev):
+def _find_joystick_aliases(joy_dev, allow_event_fallback=True):
     resolved_path = _resolve_js_device(joy_dev)
     by_id_dir = '/dev/input/by-id'
     aliases = []
@@ -54,7 +148,12 @@ def _find_joystick_aliases(joy_dev):
 
     # Some containers expose /dev/input/js* but only provide by-id aliases for
     # the event joystick node. Use that as a fallback for device-name matching.
-    if not aliases and len(joystick_event_aliases) == 1:
+    if (
+        allow_event_fallback
+        and not aliases
+        and len(joystick_event_aliases) == 1
+        and len(_list_js_devices()) <= 1
+    ):
         aliases.extend(joystick_event_aliases)
 
     return aliases
@@ -62,6 +161,37 @@ def _find_joystick_aliases(joy_dev):
 
 def _normalize_device_name(name):
     return re.sub(r'[^a-z0-9]+', ' ', name.lower()).strip()
+
+
+def _is_arm_architecture():
+    machine = platform.machine().lower()
+    return machine in ('aarch64', 'arm64') or machine.startswith('arm')
+
+
+def _ps4_controller_config_name():
+    return 'gamesir_two_arm' if _is_arm_architecture() else 'gamesir_two'
+
+
+def _find_known_joystick_names_from_proc(known_device_names):
+    matches = []
+
+    for device in _read_input_devices_from_proc():
+        name = device['name']
+        handlers = device['handlers'].split()
+        normalized = _normalize_device_name(name)
+        lowered = name.lower()
+
+        # Ignore keyboard companion interfaces such as "System Control" and
+        # "Consumer Control"; they are not the joystick stream joy_node opens.
+        if 'kbd' in handlers:
+            continue
+
+        for device_name in known_device_names:
+            if device_name in lowered or _normalize_device_name(device_name) in normalized:
+                matches.append(name)
+                break
+
+    return sorted(set(matches))
 
 
 def _detect_config_name(config_value, config_dir, joy_dev):
@@ -80,17 +210,39 @@ def _detect_config_name(config_value, config_dir, joy_dev):
         if name.endswith('.yaml')
     )
 
-    joystick_name = _read_joystick_name(joy_dev)
-    match_sources = []
-    if joystick_name:
-        match_sources.append(joystick_name)
-    match_sources.extend(_find_joystick_aliases(joy_dev))
-
     device_config_aliases = {
         'gamesir-dongle': 'gamesir',
         'gamesir': 'gamesir',
+        'logitech cordless rumblepad 2': 'default',
+        'logitech logitech cordless rumblepad 2': 'default',
+        'logitech f710 gamepad': 'default',
+        'logitech': 'default',
+        'ps4 controller': _ps4_controller_config_name(),
         'sony interactive entertainment wireless controller': 'gamesir_two',
     }
+
+    joystick_name = _read_joystick_name(joy_dev)
+    enumerated_name = _read_joystick_name_from_joy_enumerate(joy_dev)
+    proc_known_names = []
+    match_sources = []
+    allow_event_alias_fallback = True
+
+    if enumerated_name:
+        match_sources.append(enumerated_name)
+    if joystick_name and joystick_name not in match_sources:
+        match_sources.append(joystick_name)
+    if not match_sources:
+        proc_known_names = _find_known_joystick_names_from_proc(device_config_aliases.keys())
+        if len(proc_known_names) == 1:
+            match_sources.append(proc_known_names[0])
+        elif len(proc_known_names) > 1:
+            allow_event_alias_fallback = False
+            print(
+                "[INFO] Found multiple known joystick candidates "
+                f"{proc_known_names}; cannot infer which one is '{joy_dev}' from /proc alone."
+            )
+
+    match_sources.extend(_find_joystick_aliases(joy_dev, allow_event_alias_fallback))
 
     for source in match_sources:
         lowered = source.lower()

--- a/command/arms_teleop/src/joystick_teleop.cpp
+++ b/command/arms_teleop/src/joystick_teleop.cpp
@@ -23,6 +23,7 @@ JoystickTeleop::JoystickTeleop() : Node("joystick_teleop_node") {
     
     // Initialize state
     enabled_ = false;
+    waiting_for_neutral_axes_ = false;
     lastUpdateTime_ = now();
     currentTarget_ = 1; // Start with left arm
     current_mode_ = ARM_MODE; // Start with arm control mode
@@ -186,6 +187,16 @@ void JoystickTeleop::joy_callback(sensor_msgs::msg::Joy::SharedPtr msg) {
 
     // Only process axes if joystick is enabled and not in FSM mode
     if (enabled_) {
+        if (waiting_for_neutral_axes_) {
+            publishZeroCommands();
+            if (!areControlAxesNeutral(msg)) {
+                return;
+            }
+            waiting_for_neutral_axes_ = false;
+            RCLCPP_INFO(get_logger(), "🎮 Control axes are neutral, joystick motion enabled.");
+            return;
+        }
+
         // Check if LB is pressed (FSM mode - only for arm control)
         bool lb_pressed = (static_cast<size_t>(button_map_.lb_button) < msg->buttons.size()) ? 
                          msg->buttons[button_map_.lb_button] : false;
@@ -255,24 +266,14 @@ void JoystickTeleop::processButtons(const sensor_msgs::msg::Joy::SharedPtr msg) 
     if (right_stick_just_pressed) {
         enabled_ = !enabled_;
         if (enabled_) {
+            waiting_for_neutral_axes_ = true;
+            publishZeroCommands();
             RCLCPP_INFO(get_logger(), "🎮 Joystick control ENABLED!");
+            RCLCPP_INFO(get_logger(), "🎮 Waiting for control axes to return to neutral.");
         } else {
+            waiting_for_neutral_axes_ = false;
             RCLCPP_INFO(get_logger(), "🎮 Joystick control DISABLED!");
-            // Reset commands when disabling
-            if (current_mode_ == ARM_MODE) {
-                inputs_.x = 0.0;
-                inputs_.y = 0.0;
-                inputs_.z = 0.0;
-                inputs_.roll = 0.0;
-                inputs_.pitch = 0.0;
-                inputs_.yaw = 0.0;
-                publisher_->publish(inputs_);
-            } else {
-                chassis_cmd_.linear.x = 0.0;
-                chassis_cmd_.linear.y = 0.0;
-                chassis_cmd_.angular.z = 0.0;
-                chassis_publisher_->publish(chassis_cmd_);
-            }
+            publishZeroCommands();
         }
     }
     
@@ -475,6 +476,54 @@ double JoystickTeleop::applyDeadzone(double value, double deadzone) const {
         return 0.0;
     }
     return value;
+}
+
+bool JoystickTeleop::areControlAxesNeutral(const sensor_msgs::msg::Joy::SharedPtr msg) const {
+    size_t max_axis_index = std::max({
+        axes_map_.left_stick_x, axes_map_.left_stick_y,
+        axes_map_.right_stick_x, axes_map_.right_stick_y,
+        axes_map_.dpad_x, axes_map_.dpad_y
+    });
+
+    if (msg->axes.size() <= max_axis_index) {
+        return false;
+    }
+
+    const double left_stick_x = applyDeadzone(msg->axes[axes_map_.left_stick_x], axes_map_.deadzone);
+    const double left_stick_y = applyDeadzone(msg->axes[axes_map_.left_stick_y], axes_map_.deadzone);
+    const double right_stick_x = applyDeadzone(msg->axes[axes_map_.right_stick_x], axes_map_.deadzone);
+    const double right_stick_y = applyDeadzone(msg->axes[axes_map_.right_stick_y], axes_map_.deadzone);
+    const double dpad_x = applyDeadzone(msg->axes[axes_map_.dpad_x], axes_map_.dpad_deadzone);
+    const double dpad_y = applyDeadzone(msg->axes[axes_map_.dpad_y], axes_map_.dpad_deadzone);
+
+    return left_stick_x == 0.0 && left_stick_y == 0.0 &&
+           right_stick_x == 0.0 && right_stick_y == 0.0 &&
+           dpad_x == 0.0 && dpad_y == 0.0;
+}
+
+void JoystickTeleop::publishZeroCommands() {
+    inputs_.x = 0.0;
+    inputs_.y = 0.0;
+    inputs_.z = 0.0;
+    inputs_.roll = 0.0;
+    inputs_.pitch = 0.0;
+    inputs_.yaw = 0.0;
+    publisher_->publish(inputs_);
+
+    chassis_cmd_.linear.x = 0.0;
+    chassis_cmd_.linear.y = 0.0;
+    chassis_cmd_.linear.z = 0.0;
+    chassis_cmd_.angular.x = 0.0;
+    chassis_cmd_.angular.y = 0.0;
+    chassis_cmd_.angular.z = 0.0;
+    chassis_publisher_->publish(chassis_cmd_);
+
+    auto waist_cmd = std_msgs::msg::Float64();
+    auto waist_turn_cmd = std_msgs::msg::Float64();
+    waist_cmd.data = 0.0;
+    waist_turn_cmd.data = 0.0;
+    waist_lifting_publisher_->publish(waist_cmd);
+    waist_turning_publisher_->publish(waist_turn_cmd);
 }
 
 void JoystickTeleop::processChassisAxes(const sensor_msgs::msg::Joy::SharedPtr msg) {


### PR DESCRIPTION
## Summary
- add ARM-specific GameSir/PS4 controller mapping config
- improve joystick config auto-detection across device names and architectures
- add neutral-axis guard before enabling joystick motion
- publish zero arm/chassis/waist commands when disabling control

## Test
- verified branch origin/gamesir_all contains only committed joystick teleop changes