### PR TITLE
Refine VR follow frame 

### DIFF
--- a/command/arms_target_manager/VR_INPUT_HANDLER_README.md
+++ b/command/arms_target_manager/VR_INPUT_HANDLER_README.md
@@ -53,9 +53,9 @@ VRInputHandler是基于VRMarkerWrapper功能开发的VR输入处理器，专门�
 ### 启动参数
 - `enable_vr`: 是否启用VR控制，默认true
 - `vr_update_rate`: VR更新频率，默认500.0Hz
-- `vr_follow_frame`: FULL_BODY 下 VR 末端目标计算坐标系，默认 `base_footprint`
+- `vr_follow_frame`: VR 末端目标计算坐标系，FULL_BODY / SPLIT_BODY 均生效，默认 `base_footprint`
 
-### FULL_BODY 目标坐标系
+### VR 目标坐标系
 
 `vr_follow_frame` 默认是 `base_footprint`。进入 UPDATE/rebase 时，
 `VRInputHandler` 将 current pose 从其 `header.frame_id` 转换到
@@ -65,6 +65,8 @@ VRInputHandler是基于VRMarkerWrapper功能开发的VR输入处理器，专门�
 - mobile-base：通常为 `world -> base_footprint` 锁存，
   `base_footprint -> world` 发布；
 - fixed-base：通常两个 frame 都是 `base_footprint`，直接复制；
+- split-body：可设为 `arm_base`，将 VR 增量表达在机械臂基座轴系，
+  发布前再从 `arm_base` 转到 current-pose frame；
 - TF 不可用：跳过本周期，不更新缓存，下一条 VR 输入自动重试。
 - `robot.local.yaml` 只选择 `info_file_name`，不配置本参数。
 
@@ -264,7 +266,7 @@ VRInputHandler会输出详细的调试信息：
 
 ## 注意事项
 
-1. **坐标系一致性**: FULL_BODY 下计算在 `vr_follow_frame`，发布前转换到 `ee_frame_id_`；非全身控制保持旧语义
+1. **坐标系一致性**: 所有控制拓扑都在 `vr_follow_frame` 下计算，发布前转换到 `ee_frame_id_`
 2. **频率匹配**: VR更新频率应与系统处理能力匹配
 3. **阈值调整**: 根据实际需求调整变化检测阈值
 4. **线程安全**: 所有状态变量都使用原子操作确保线程安全

--- a/command/arms_target_manager/config/default.yaml
+++ b/command/arms_target_manager/config/default.yaml
@@ -22,7 +22,7 @@
     # VR手柄位姿缩放因子（左右共用，可由组合键动态校准，范围建议 [0.75, 1.5]）
     vr_pose_scale: 1.0
 
-    # FULL_BODY 下 VR 末端目标保持所在的机器人跟随坐标系
+    # VR 末端目标保持所在的机器人跟随坐标系（FULL_BODY / SPLIT_BODY 均生效）
     vr_follow_frame: base_footprint
 
     # 是否启用VR输入处理

--- a/command/arms_target_manager/include/arms_target_manager/VRInputHandler.h
+++ b/command/arms_target_manager/include/arms_target_manager/VRInputHandler.h
@@ -56,7 +56,7 @@ namespace arms_ros2_control::command
          * @param vr_thumbstick_angular_scale VR摇杆角度缩放因子（单位 rad/step）
          * @param vr_pose_scale 手柄位姿位置缩放因子（左右共用；事件 15 左Y+右B 固定按左侧 Z 距校准）
          * @param reference_link 参考link名称（例如 head_link2），用于VR/头显关联
-         * @param vr_follow_frame FULL_BODY 下 VR 末端目标计算坐标系（默认 base_footprint）
+         * @param vr_follow_frame VR 末端目标计算坐标系（默认 base_footprint）
          */
         VRInputHandler(
             rclcpp::Node::SharedPtr node,
@@ -383,7 +383,7 @@ namespace arms_ros2_control::command
 
         /**
          * 将计算坐标系下的目标转换到控制发布 frame，再做变化检测并发布到 left_target/right_target。
-         * FULL_BODY 下 position/orientation 为 vr_follow_frame_ Pose；非 FULL_BODY 保持旧语义。
+         * position/orientation 为 vr_follow_frame_ Pose。
          * @param armType 手臂类型 ("left" 或 "right")
          * @param position 计算坐标系下的位置
          * @param orientation 计算坐标系下的方向
@@ -426,7 +426,7 @@ namespace arms_ros2_control::command
 
         /**
          * 记录最后一次实际发布出去的目标位姿，用作暂停恢复/进入 UPDATE 的 command 连续性基准。
-         * FULL_BODY 下保存的是 vr_follow_frame_ Pose。
+         * 保存的是 vr_follow_frame_ Pose。
          * @param armType 手臂类型 ("left" 或 "right")
          * @param position 计算坐标系下的位置
          * @param orientation 计算坐标系下的方向
@@ -442,7 +442,7 @@ namespace arms_ros2_control::command
 
         /**
          * 将对应手臂的 robot base 设置为最后 command target；若还没有发布历史，则回退到 current pose。
-         * FULL_BODY 下 current pose 会从 ee_frame_id_ 转到 vr_follow_frame_；失败时不覆盖基准。
+         * current pose 会从 ee_frame_id_ 转到 vr_follow_frame_；失败时不覆盖基准。
          * @param armType 手臂类型 ("left" 或 "right")
          * @return true 表示基准已在正确计算 frame 中建立
          */
@@ -561,14 +561,13 @@ namespace arms_ros2_control::command
         Eigen::Vector3d vr_head_position_ = Eigen::Vector3d::Zero();
         Eigen::Quaterniond vr_head_orientation_ = Eigen::Quaterniond::Identity();
 
-        // 最后实际发布 frame（FULL_BODY 下为 ee_frame_id_）的 Pose，仅用于变化检测
+        // 最后实际发布 frame（ee_frame_id_）的 Pose，仅用于变化检测
         Eigen::Vector3d prev_calculated_left_position_ = Eigen::Vector3d::Zero();
         Eigen::Quaterniond prev_calculated_left_orientation_ = Eigen::Quaterniond::Identity();
         Eigen::Vector3d prev_calculated_right_position_ = Eigen::Vector3d::Zero();
         Eigen::Quaterniond prev_calculated_right_orientation_ = Eigen::Quaterniond::Identity();
 
-        // 最后一次实际发布对应的计算-frame command target：
-        // FULL_BODY 下为 vr_follow_frame_ Pose；非 FULL_BODY 保持旧语义。
+        // 最后一次实际发布对应的计算-frame command target（vr_follow_frame_ Pose）。
         bool has_last_published_left_target_ = false;
         Eigen::Vector3d last_published_left_position_ = Eigen::Vector3d::Zero();
         Eigen::Quaterniond last_published_left_orientation_ = Eigen::Quaterniond::Identity();
@@ -657,7 +656,7 @@ namespace arms_ros2_control::command
         Eigen::Vector3d vr_base_right_position_ = Eigen::Vector3d::Zero();
         Eigen::Quaterniond vr_base_right_orientation_ = Eigen::Quaterniond::Identity();
 
-        // 机器人末端基准：FULL_BODY 下为 vr_follow_frame_ 中锁存的 Pose；非全身控制保持旧语义
+        // 机器人末端基准：vr_follow_frame_ 中锁存的 Pose
         Eigen::Vector3d robot_base_left_position_ = Eigen::Vector3d::Zero();
         Eigen::Quaterniond robot_base_left_orientation_ = Eigen::Quaterniond::Identity();
         Eigen::Vector3d robot_base_right_position_ = Eigen::Vector3d::Zero();
@@ -740,7 +739,7 @@ namespace arms_ros2_control::command
         // 参考link名称（用于将VR头显/手柄关联到机器人某个link），从target_manager.yaml读取，默认"base_link"
         std::string reference_link_;
 
-        // FULL_BODY VR 目标的计算坐标系；由 vr_follow_frame 参数配置
+        // VR 目标的计算坐标系；由 vr_follow_frame 参数配置
         std::string vr_follow_frame_;
 
         // 来自 left_current_pose/right_current_pose.header.frame_id；

--- a/command/arms_target_manager/src/VRInputHandler.cpp
+++ b/command/arms_target_manager/src/VRInputHandler.cpp
@@ -467,13 +467,12 @@ namespace arms_ros2_control::command
                     vr_right_position_raw_.x(), vr_right_position_raw_.y(), vr_right_position_raw_.z(),
                     head_ctrl_dist);
 
-        // 计算系：与 publishTargetPoseDirect 保持一致——FULL_BODY 下目标相对底盘保持
-        // （vr_follow_frame_），其余情况计算系就是发布系。
-        // 手柄-头显偏移量来自 VR 世界系（已在 xr 侧转成前x/左y/上z，与底盘轴系同向），
-        // 必须在底盘系里做加法。直接加在 ee_frame_id_ 上时，轮式底盘的 ee_frame_id_
-        // 是 world，底盘一转向偏移方向就整体转错。
-        const std::string& calc_frame =
-            isFullBodyMode() ? vr_follow_frame_ : ee_frame_id_;
+        // 计算系：与 publishTargetPoseDirect 保持一致，所有控制拓扑都在
+        // vr_follow_frame_ 中计算，发布前再转回 ee_frame_id_。
+        // 手柄-头显偏移量来自 VR 世界系（已在 xr 侧转成前x/左y/上z），其分量按
+        // vr_follow_frame_ 的轴系解释。直接加在 ee_frame_id_ 上时，轮式底盘的
+        // ee_frame_id_ 是 world，底盘一转向偏移方向就整体转错。
+        const std::string& calc_frame = vr_follow_frame_;
 
         double ee_dist_from_ref = std::numeric_limits<double>::quiet_NaN();
         Eigen::Vector3d p_C_ref = Eigen::Vector3d::Zero();
@@ -1311,14 +1310,6 @@ namespace arms_ros2_control::command
             return true;
         }
 
-        if (!isFullBodyMode())
-        {
-            basePosition = currentPosition;
-            baseOrientation = currentOrientation.normalized();
-            valid = true;
-            return true;
-        }
-
         Eigen::Vector3d transformedPosition;
         Eigen::Quaterniond transformedOrientation;
         if (!ee_frame_id_initialized_ ||
@@ -1465,22 +1456,19 @@ namespace arms_ros2_control::command
             return false;
         }
 
-        Eigen::Vector3d publishPosition = position;
-        Eigen::Quaterniond publishOrientation = orientation;
-        if (isFullBodyMode())
+        Eigen::Vector3d publishPosition;
+        Eigen::Quaterniond publishOrientation;
+        if (!ee_frame_id_initialized_ ||
+            !transformPoseBetweenFrames(
+                armType,
+                position,
+                orientation,
+                vr_follow_frame_,
+                ee_frame_id_,
+                publishPosition,
+                publishOrientation))
         {
-            if (!ee_frame_id_initialized_ ||
-                !transformPoseBetweenFrames(
-                    armType,
-                    position,
-                    orientation,
-                    vr_follow_frame_,
-                    ee_frame_id_,
-                    publishPosition,
-                    publishOrientation))
-            {
-                return false;
-            }
+            return false;
         }
 
         Eigen::Vector3d& previousPosition = isLeft
@@ -3165,7 +3153,7 @@ namespace arms_ros2_control::command
                         "🕹️ UPDATE bases: left=%s, right=%s, calculation_frame=%s",
                         leftBaseReady ? "ready" : "pending_tf",
                         rightBaseReady ? "ready" : "pending_tf",
-                        isFullBodyMode() ? vr_follow_frame_.c_str() : ee_frame_id_.c_str());
+                        vr_follow_frame_.c_str());
 
                     // 重置摇杆累积偏移
                     left_thumbstick_offset_ = Eigen::Vector3d::Zero();

--- a/command/arms_target_manager/src/arms_target_manager_node.cpp
+++ b/command/arms_target_manager/src/arms_target_manager_node.cpp
@@ -31,7 +31,7 @@ int main(int argc, char** argv)
     double vr_pose_scale = node->declare_parameter("vr_pose_scale", 1.0);
     // VR/头显参考link（通常为机器人头部link），可在各机器人target_manager.yaml中配置
     std::string reference_link = node->declare_parameter("reference_link", "head_link2");
-    // FULL_BODY 下 VR 末端目标计算所在的跟随坐标系
+    // VR 末端目标计算所在的跟随坐标系
     std::string vr_follow_frame =
         node->declare_parameter("vr_follow_frame", "base_footprint");
     if (vr_follow_frame.empty())
@@ -116,7 +116,7 @@ int main(int argc, char** argv)
                     reference_link.c_str());
         RCLCPP_INFO(
             node->get_logger(),
-            "VR follow frame: %s (used by FULL_BODY VR target mapping)",
+            "VR follow frame: %s (used by VR target mapping)",
             vr_follow_frame.c_str());
     }
 

--- a/controller/ocs2_arm_controller/src/Ocs2ArmController.cpp
+++ b/controller/ocs2_arm_controller/src/Ocs2ArmController.cpp
@@ -248,7 +248,7 @@ namespace ocs2::mobile_manipulator
             auto_declare<std::string>("movej_interpolation_type", "linear");
             auto_declare<double>("movej_tanh_scale", 3.0);
             auto_declare<double>("movej_trajectory_duration", 3.0);
-            auto_declare<double>("movej_trajectory_blend_ratio", 0.0);
+            auto_declare<double>("movej_trajectory_blend_ratio", 0.2);
             auto_declare<double>("movej_max_velocity", 2.0);
             auto_declare<double>("movej_max_acceleration", 4.0);
             auto_declare<double>("movej_max_jerk", 20.0);


### PR DESCRIPTION
## 背景

`vr_follow_frame` 原先只在 FULL_BODY 拓扑生效。SPLIT_BODY 直接在末端控制 frame 中计算 VR 目标，无法选择 `arm_base` 等机器人跟随坐标系表达手柄增量。

此外，`ocs2_arm_controller` 未显式配置时，MoveJ 多路点轨迹融合比例默认为 `0.2`。

## 修改内容

- 将 `vr_follow_frame` 扩展至 FULL_BODY 和 SPLIT_BODY：
  - 进入 UPDATE/rebase 时，将 current pose 从 `ee_frame_id_` 转换至 `vr_follow_frame` 并锁存。
  - 在 `vr_follow_frame` 中计算 VR 增量目标。
  - 发布前将目标从 `vr_follow_frame` 转换回 `ee_frame_id_`。
- SPLIT_BODY 可将 `vr_follow_frame` 配置为 `arm_base`，使 VR 增量按机械臂基座轴系表达。
- TF 不可用时跳过当前目标，不更新目标缓存，后续 VR 输入自动重试。
- 保持 `vr_follow_frame` 默认值为 `base_footprint`；source frame 与 target frame 相同时直接复制。
- 将 `ocs2_arm_controller` 的 `movej_trajectory_blend_ratio` 源码默认值从 `0.0` 调整为 `0.2`。
- 同步更新参数注释、启动日志和 VR 使用文档。

## 兼容性

- FULL_BODY 保持原有 `vr_follow_frame` 计算及转换语义。
- SPLIT_BODY 默认仍使用 `base_footprint`；当 current-pose frame 同为 `base_footprint` 时，行为基本不变。
- `movej_trajectory_blend_ratio` 的 YAML 显式配置仍优先于源码默认值。