### PR TITLE
Enhance VRInputHandler with stale catch-up ramp for smoother pose recovery

### DIFF
--- a/command/arms_target_manager/VR_INPUT_HANDLER_README.md
+++ b/command/arms_target_manager/VR_INPUT_HANDLER_README.md
@@ -11,7 +11,7 @@ VRInputHandler是基于VRMarkerWrapper功能开发的VR输入处理器，专门�
 ### 核心功能
 - **VR Pose订阅**: 订阅VR左右臂的末端执行器pose
 - **状态切换机制**: 通过右摇杆点击在存储模式和更新模式之间切换
-- **频闪优化**: 基于阈值检测pose变化，避免不必要的marker更新
+- **连续目标**: 每个有效VR pose回调均发布目标；变化阈值代码暂时保留但不生效
 - **差值计算**: 基于存储的base pose计算相对变化并应用到机器人
 - **控制拓扑检测**: 启动时查询 `/controller_manager/list_controllers`，区分 FULL_BODY / SPLIT_BODY
 - **全身模式命令**: FULL_BODY 下通过 `/mode_command` 请求 WBC 身体/底盘/双臂/单臂状态
@@ -229,9 +229,9 @@ ros2 launch ocs2_arm_controller full_body.launch.py \
 
 ## 技术细节
 
-### 变化检测阈值
-- `POSITION_THRESHOLD`: 位置变化阈值，默认1cm
-- `ORIENTATION_THRESHOLD`: 方向变化阈值，默认0.005弧度
+### 变化检测阈值（暂时禁用）
+- `POSITION_THRESHOLD`: 原位置变化阈值1cm，代码保留用于A/B回退，当前不参与发布判断
+- `ORIENTATION_THRESHOLD`: 原方向变化阈值0.005弧度，代码保留用于A/B回退，当前不参与发布判断
 
 ### 差值计算算法
 ```cpp
@@ -283,7 +283,6 @@ VRInputHandler会输出详细的调试信息：
 
 2. **Marker不更新**
    - 确认已点按右摇杆切换到更新模式
-   - 检查pose变化是否超过阈值
    - 确认ArmsTargetManager正常工作
    - FULL_BODY 下确认该臂未被 WBC 禁用，且不在身体模式 pending 中
 

--- a/command/arms_target_manager/include/arms_target_manager/VRInputHandler.h
+++ b/command/arms_target_manager/include/arms_target_manager/VRInputHandler.h
@@ -393,6 +393,25 @@ namespace arms_ros2_control::command
                                      const Eigen::Vector3d& position,
                                      const Eigen::Quaterniond& orientation);
 
+        /**
+         * 冻结追赶斜坡：上游 XR 位姿在链路数据未更新时会逐位重发上一帧，恢复后
+         * 一帧补上整段位移（实测最大 124.7mm / 11.5°）。这里检测冻结，并把追赶量
+         * 按冻结帧数等额摊到随后若干帧，使正常运动逐位不受影响。
+         * 仅在真正发布 target 的路径上调用，因此 STORAGE 模式下不生效。
+         * @param isLeft true=左臂状态，false=右臂状态
+         * @param position 计算坐标系下的位置，原地改写为摊平后的值
+         * @param orientation 计算坐标系下的方向，原地改写为摊平后的值
+         */
+        void applyStaleCatchUpRamp(bool isLeft,
+                                   Eigen::Vector3d& position,
+                                   Eigen::Quaterniond& orientation);
+
+        /** 清空冻结追赶斜坡状态；下一帧重新起基准，不会摊平。 */
+        void resetStaleCatchUpRamp(bool isLeft);
+
+        /** 左右臂一起清空。 */
+        void resetStaleCatchUpRamp();
+
         /** 读取 ArmsTargetManager 中 WBC 已确认的双臂耦合状态。 */
         bool isBimanualCoupled() const;
 
@@ -576,6 +595,25 @@ namespace arms_ros2_control::command
         Eigen::Vector3d last_published_right_position_ = Eigen::Vector3d::Zero();
         Eigen::Quaterniond last_published_right_orientation_ = Eigen::Quaterniond::Identity();
 
+        // 冻结追赶斜坡状态（每臂一份），语义见 applyStaleCatchUpRamp()。
+        struct StaleCatchUpRamp
+        {
+            bool has_previous_input = false;
+            // 上一帧进入斜坡的原始目标，用于逐位比较判定"上游冻结"
+            Eigen::Vector3d previous_input_position = Eigen::Vector3d::Zero();
+            Eigen::Quaterniond previous_input_orientation = Eigen::Quaterniond::Identity();
+            int frozen_frames = 0;
+            // 上一帧实际发出的目标，解冻帧据此测量缺口
+            Eigen::Vector3d output_position = Eigen::Vector3d::Zero();
+            Eigen::Quaterniond output_orientation = Eigen::Quaterniond::Identity();
+            // 尚未交付的追赶量；remaining_frames 归零时必然为零
+            Eigen::Vector3d residual_position = Eigen::Vector3d::Zero();
+            Eigen::Quaterniond residual_orientation = Eigen::Quaterniond::Identity();
+            int remaining_frames = 0;
+        };
+        StaleCatchUpRamp left_stale_ramp_;
+        StaleCatchUpRamp right_stale_ramp_;
+
         // 状态管理
         std::atomic<bool> enabled_;
         std::atomic<bool> is_update_mode_; // true = 更新模式, false = 存储模式
@@ -756,5 +794,8 @@ namespace arms_ros2_control::command
         static const std::string XR_NODE_NAME;
         static const double POSITION_THRESHOLD;
         static const double ORIENTATION_THRESHOLD;
+        // 连续多少帧原始目标逐位相同才判定为上游冻结。实测冻结长度呈双峰分布
+        // （1 帧 / ≥5 帧），2..5 取任意值结果相同，取下界即可。
+        static const int STALE_MIN_FROZEN_FRAMES;
     };
 } // namespace arms_ros2_control::command

--- a/command/arms_target_manager/src/VRInputHandler.cpp
+++ b/command/arms_target_manager/src/VRInputHandler.cpp
@@ -29,6 +29,7 @@ namespace arms_ros2_control::command
     const std::string VRInputHandler::XR_NODE_NAME = "/xr_target_node";
     const double VRInputHandler::POSITION_THRESHOLD = 0.01; // 1cm threshold for position changes
     const double VRInputHandler::ORIENTATION_THRESHOLD = 0.005; // threshold for orientation changes (quaternion angle)
+    const int VRInputHandler::STALE_MIN_FROZEN_FRAMES = 2; // 连续 >=2 帧逐位相同即判定上游冻结
 
     VRInputHandler::VRInputHandler(
         rclcpp::Node::SharedPtr node,
@@ -83,6 +84,10 @@ namespace arms_ros2_control::command
         // 初始化 TF 组件（用于在 reference_link 与末端 frame 之间进行坐标变换）
         tf_buffer_ = std::make_shared<tf2_ros::Buffer>(node_->get_clock());
         tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);
+        RCLCPP_INFO(
+            node_->get_logger(),
+            "VR stale-input catch-up ramp recovery is enabled (frozen >= %d identical frames).",
+            STALE_MIN_FROZEN_FRAMES);
         // 检测左右控制器名称
         detectGripperControllers(hand_controllers_);
         
@@ -445,6 +450,8 @@ namespace arms_ros2_control::command
         mirror_mode_.store(false);
         RCLCPP_INFO(node_->get_logger(), "🔘 [%s] 已切换至非镜像模式", tag);
         is_update_mode_.store(false);
+        // 目标流在此中断/重启，清空斜坡，避免用陈旧输出量缺口
+        resetStaleCatchUpRamp();
         RCLCPP_INFO(node_->get_logger(),
                     "🔘 [%s] 自动切换到 STORAGE 模式 - 正在更新映射尺度，请重新进入 UPDATE 模式",
                     tag);
@@ -847,6 +854,7 @@ namespace arms_ros2_control::command
         right_wbc_toggle_request_pending_.store(false);
         requested_wbc_toggle_target_.store(WbcToggleTarget::NONE);
         resetYbModeLatchAndConversions();
+        resetStaleCatchUpRamp();
         RCLCPP_INFO(node_->get_logger(), "🕹️🕶️🕹️ VR control DISABLED!");
 
         // 禁用 VR 控制时，若处于底盘模式则退出并清零底盘/腰部命令，防止残留运动
@@ -1174,6 +1182,8 @@ namespace arms_ros2_control::command
 
         left_robot_base_valid_ = false;
         right_robot_base_valid_ = false;
+
+        resetStaleCatchUpRamp();
     }
 
     bool VRInputHandler::transformPoseBetweenFrames(
@@ -1395,6 +1405,7 @@ namespace arms_ros2_control::command
     void VRInputHandler::rebaseRightArmVrControl()
     {
         const bool paused = right_arm_paused_.load();
+        resetStaleCatchUpRamp(false);
 
         if (mirror_mode_.load())
         {
@@ -1465,15 +1476,21 @@ namespace arms_ros2_control::command
             return false;
         }
 
-        Eigen::Vector3d publishPosition = position;
-        Eigen::Quaterniond publishOrientation = orientation;
+        // 上游 XR 位姿冻结后会一帧补齐整段位移，先把追赶量摊到随后若干帧。
+        // 放在 frame 变换之前，使 recordLastPublishedTarget() 记录的也是真正发出去的目标。
+        Eigen::Vector3d rampedPosition = position;
+        Eigen::Quaterniond rampedOrientation = orientation;
+        applyStaleCatchUpRamp(isLeft, rampedPosition, rampedOrientation);
+
+        Eigen::Vector3d publishPosition = rampedPosition;
+        Eigen::Quaterniond publishOrientation = rampedOrientation;
         if (isFullBodyMode())
         {
             if (!ee_frame_id_initialized_ ||
                 !transformPoseBetweenFrames(
                     armType,
-                    position,
-                    orientation,
+                    rampedPosition,
+                    rampedOrientation,
                     vr_follow_frame_,
                     ee_frame_id_,
                     publishPosition,
@@ -1489,6 +1506,9 @@ namespace arms_ros2_control::command
         Eigen::Quaterniond& previousOrientation = isLeft
             ? prev_calculated_left_orientation_
             : prev_calculated_right_orientation_;
+        // Temporarily disable pose-change threshold filtering so every valid XR pose
+        // callback publishes a target. Keep the original gate for quick A/B rollback.
+        /*
         // Coupled: keep left_target heartbeating even when the left controller is still,
         // otherwise the 0.2s leader timeout lets right_target steal and inverse-sync left.
         const bool leftCoupledHeartbeat = bimanualCoupled && isLeft;
@@ -1501,6 +1521,7 @@ namespace arms_ros2_control::command
         {
             return false;
         }
+        */
 
         geometry_msgs::msg::Pose pose;
         pose.position.x = publishPosition.x();
@@ -1520,7 +1541,7 @@ namespace arms_ros2_control::command
             pub_right_target_->publish(pose);
         }
 
-        recordLastPublishedTarget(armType, position, orientation);
+        recordLastPublishedTarget(armType, rampedPosition, rampedOrientation);
         previousPosition = publishPosition;
         previousOrientation = publishOrientation.normalized();
         return true;
@@ -1574,6 +1595,118 @@ namespace arms_ros2_control::command
         }
 
         return false;
+    }
+
+    void VRInputHandler::applyStaleCatchUpRamp(bool isLeft,
+                                               Eigen::Vector3d& position,
+                                               Eigen::Quaterniond& orientation)
+    {
+        StaleCatchUpRamp& ramp = isLeft ? left_stale_ramp_ : right_stale_ramp_;
+
+        const Eigen::Vector3d inputPosition = position;
+        const Eigen::Quaterniond inputOrientation = orientation;
+
+        if (!ramp.has_previous_input)
+        {
+            ramp.has_previous_input = true;
+            ramp.previous_input_position = inputPosition;
+            ramp.previous_input_orientation = inputOrientation;
+            ramp.output_position = inputPosition;
+            ramp.output_orientation = inputOrientation;
+            return;
+        }
+
+        // 逐位比较：上游冻结时 xr_target_node 重发同一帧，而本文件的换算是确定性的，
+        // 于是算出的目标也逐位相同；摇杆偏移等真实指令运动不会命中这一条。
+        const bool identical =
+            inputPosition == ramp.previous_input_position &&
+            inputOrientation.coeffs() == ramp.previous_input_orientation.coeffs();
+
+        ramp.previous_input_position = inputPosition;
+        ramp.previous_input_orientation = inputOrientation;
+
+        bool armedThisFrame = false;
+        if (identical)
+        {
+            ++ramp.frozen_frames;
+        }
+        else
+        {
+            if (ramp.frozen_frames >= STALE_MIN_FROZEN_FRAMES)
+            {
+                // 解冻帧：缺口 = 当前输入 - 当前输出，摊开帧数 N = 冻结帧数。
+                // 缺口是现场量出来的，因此上一次斜坡没还完的部分会自动计入。
+                const int spread = ramp.frozen_frames;
+                const double keep =
+                    static_cast<double>(spread - 1) / static_cast<double>(spread);
+
+                Eigen::Quaterniond aligned = inputOrientation;
+                if (aligned.dot(ramp.output_orientation) < 0.0)
+                {
+                    aligned.coeffs() = -aligned.coeffs();
+                }
+
+                const Eigen::Vector3d gap = inputPosition - ramp.output_position;
+                ramp.residual_position = gap * keep;
+                ramp.residual_orientation = Eigen::Quaterniond::Identity().slerp(
+                    keep,
+                    (ramp.output_orientation.conjugate() * aligned).normalized());
+                ramp.remaining_frames = spread - 1;
+                armedThisFrame = true;
+
+                RCLCPP_DEBUG(
+                    node_->get_logger(),
+                    "🕹️ [%s] XR 冻结 %d 帧，追赶 %.1fmm 分摊到 %d 帧",
+                    isLeft ? "left" : "right",
+                    spread,
+                    gap.norm() * 1000.0,
+                    spread);
+            }
+            ramp.frozen_frames = 0;
+        }
+
+        if (!armedThisFrame && ramp.remaining_frames > 0)
+        {
+            // 等额递减：残差 <- 残差 * (剩余-1)/剩余，最后一帧精确归零。
+            const double keep = static_cast<double>(ramp.remaining_frames - 1) /
+                                static_cast<double>(ramp.remaining_frames);
+            ramp.residual_position *= keep;
+            ramp.residual_orientation =
+                Eigen::Quaterniond::Identity().slerp(keep, ramp.residual_orientation);
+            --ramp.remaining_frames;
+            if (ramp.remaining_frames == 0)
+            {
+                ramp.residual_position.setZero();
+                ramp.residual_orientation.setIdentity();
+            }
+        }
+
+        if (ramp.remaining_frames > 0)
+        {
+            Eigen::Quaterniond aligned = inputOrientation;
+            if (aligned.dot(ramp.output_orientation) < 0.0)
+            {
+                aligned.coeffs() = -aligned.coeffs();
+            }
+            position = inputPosition - ramp.residual_position;
+            orientation =
+                (aligned * ramp.residual_orientation.conjugate()).normalized();
+        }
+        // 无残差时不改写入参，正常运动逐位不受影响。
+
+        ramp.output_position = position;
+        ramp.output_orientation = orientation;
+    }
+
+    void VRInputHandler::resetStaleCatchUpRamp(bool isLeft)
+    {
+        (isLeft ? left_stale_ramp_ : right_stale_ramp_) = StaleCatchUpRamp{};
+    }
+
+    void VRInputHandler::resetStaleCatchUpRamp()
+    {
+        left_stale_ramp_ = StaleCatchUpRamp{};
+        right_stale_ramp_ = StaleCatchUpRamp{};
     }
 
     void VRInputHandler::calculatePoseFromDifference(const Eigen::Vector3d& vrCurrentPos,
@@ -2410,12 +2543,14 @@ namespace arms_ros2_control::command
             has_last_published_left_target_ = false;
             last_published_left_position_.setZero();
             last_published_left_orientation_.setIdentity();
+            resetStaleCatchUpRamp(true);
         }
         else if (armType == "right")
         {
             has_last_published_right_target_ = false;
             last_published_right_position_.setZero();
             last_published_right_orientation_.setIdentity();
+            resetStaleCatchUpRamp(false);
         }
     }
 
@@ -2443,6 +2578,7 @@ namespace arms_ros2_control::command
         {
             return false;
         }
+        resetStaleCatchUpRamp(isLeftArm);
 
         if (useLeftVr)
         {
@@ -2630,6 +2766,7 @@ namespace arms_ros2_control::command
         {
             right_arm_paused_.store(true);
         }
+        resetStaleCatchUpRamp(isLeftArm);
     }
 
     void VRInputHandler::clearArmPause(WbcToggleTarget arm)
@@ -2659,6 +2796,7 @@ namespace arms_ros2_control::command
             paused_right_position_ = Eigen::Vector3d::Zero();
             paused_right_orientation_ = Eigen::Quaterniond::Identity();
         }
+        resetStaleCatchUpRamp(isLeftArm);
     }
 
     bool VRInputHandler::handleCase16YbModeToggle()
@@ -3208,6 +3346,8 @@ namespace arms_ros2_control::command
                     }
 
                     is_update_mode_.store(true);
+                    // 目标流在此中断/重启，清空斜坡，避免用陈旧输出量缺口
+                    resetStaleCatchUpRamp();
                     RCLCPP_INFO(node_->get_logger(), "🔘 [右摇杆按钮] 按下 - 功能: 切换UPDATE/STORAGE模式 - 操作: 切换到UPDATE模式（已存储基准位姿，重置摇杆偏移）");
                     RCLCPP_DEBUG(node_->get_logger(),
                                 "   VR Base Positions: Left [%.3f, %.3f, %.3f], Right [%.3f, %.3f, %.3f]",
@@ -3227,6 +3367,8 @@ namespace arms_ros2_control::command
                 {
                     // 切换到存储模式
                     is_update_mode_.store(false);
+                    // 目标流在此中断/重启，清空斜坡，避免用陈旧输出量缺口
+                    resetStaleCatchUpRamp();
                     RCLCPP_INFO(node_->get_logger(), "🔘 [右摇杆按钮] 按下 - 功能: 切换UPDATE/STORAGE模式 - 操作: 切换到STORAGE模式（准备存储新的基准位姿）");
                 }
                 break;
@@ -3377,6 +3519,8 @@ namespace arms_ros2_control::command
                 if (is_update_mode_.load())
                 {
                     is_update_mode_.store(false);
+                    // 目标流在此中断/重启，清空斜坡，避免用陈旧输出量缺口
+                    resetStaleCatchUpRamp();
                     // 重置摇杆累积偏移
                     left_thumbstick_offset_ = Eigen::Vector3d::Zero();
                     right_thumbstick_offset_ = Eigen::Vector3d::Zero();
@@ -3497,9 +3641,9 @@ namespace arms_ros2_control::command
                 toggleGripperPercentMode(false);
                 break;
             }
-            case 15: // 左Y+右B：尺度对齐（固定用左侧 Z 距）
+            case 15: // 左Y+右B：尺度对齐（功能未完善，暂时禁用）
             {
-                runScaleCalibration(true);
+                // runScaleCalibration(true);
                 break;
             }
             case 16: // 左右握把+左Y+右B：切换 FULL_BODY 下 Y/B 禁用↔暂停
@@ -3762,6 +3906,8 @@ namespace arms_ros2_control::command
                 if (is_update_mode_.load())
                 {
                     is_update_mode_.store(false);
+                    // 目标流在此中断/重启，清空斜坡，避免用陈旧输出量缺口
+                    resetStaleCatchUpRamp();
                     // 重置摇杆累积偏移
                     left_thumbstick_offset_ = Eigen::Vector3d::Zero();
                     right_thumbstick_offset_ = Eigen::Vector3d::Zero();


### PR DESCRIPTION
## Summary

- Add per-hand stale-input tracking for VR pose targets.
  - Detect six or more consecutive identical XR input frames.
  - On recovery, distribute the gap between the latest XR input and previous output across subsequent frames, avoiding an abrupt target jump.
  - Keep normal pose updates unmodified when no stale-input recovery is active.
- Publish every valid XR pose callback instead of suppressing unchanged poses through the pose-change threshold.
- Reset stale-input ramp state with existing VR mode, input, and target-stream reset paths, preventing residual state from crossing control transitions.
- Add startup and debug logging for stale-input catch-up behavior.
- Document continuous target publishing and stale-input catch-up ramp recovery in `VR_INPUT_HANDLER_README.md`.
