### PR TITLE
fix(ci): prefer Azure apt mirrors and allow rosdep cache writes

### DIFF
--- a/.github/workflows/release-arms-ros2-control-deb.yml
+++ b/.github/workflows/release-arms-ros2-control-deb.yml
@@ -48,6 +48,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_type == 'tag' && github.ref_name || (github.event_name == 'pull_request' && 'pre-release' || github.ref) }}

--- a/.github/workflows/release-arms-ros2-control-deb.yml
+++ b/.github/workflows/release-arms-ros2-control-deb.yml
@@ -10,6 +10,10 @@
 #
 # Retired: standalone gripper / per-hardware debs / arms-ros2-control-jazzy-wbc.
 # Requires PRIVATE_SUBMODULES_TOKEN (selective submodule init; never submodules: recursive). Debs: install only, no .cpp.
+#
+# Container apt: ros:jazzy images pin Canonical archive.ubuntu.com / ports.ubuntu.com,
+# which time out from GitHub-hosted Azure VMs. Jobs rewrite those URIs to Azure-first
+# mirror lists with short Acquire timeouts so apt fails over in seconds, not minutes.
 
 name: Build arms-ros2-control deb
 
@@ -105,10 +109,53 @@ jobs:
       image: ${{ matrix.image }}
 
     steps:
-      - name: Install GitHub CLI
+      - name: Configure apt and install GitHub CLI
+        timeout-minutes: 8
         shell: bash
         run: |
           set -eo pipefail
+          export DEBIAN_FRONTEND=noninteractive
+
+          # ros:* containers do not inherit the runner image's Azure apt mirrors.
+          cat >/etc/apt/apt.conf.d/99-ci-acquire <<'EOF'
+          Acquire::Retries "1";
+          Acquire::http::Timeout "15";
+          Acquire::https::Timeout "15";
+          Acquire::Languages "none";
+          Acquire::IndexTargets::deb::DEP-11::DefaultEnabled "false";
+          EOF
+
+          mirrors_file=/etc/apt/ci-ubuntu-mirrors.txt
+          if [[ "$(dpkg --print-architecture)" == "arm64" ]]; then
+            printf '%s\n' \
+              $'http://azure.ports.ubuntu.com/ubuntu-ports/\tpriority:1' \
+              $'http://ports.ubuntu.com/ubuntu-ports/\tpriority:2' \
+              > "$mirrors_file"
+          else
+            printf '%s\n' \
+              $'http://azure.archive.ubuntu.com/ubuntu/\tpriority:1' \
+              $'http://archive.ubuntu.com/ubuntu/\tpriority:2' \
+              $'http://security.ubuntu.com/ubuntu/\tpriority:3' \
+              > "$mirrors_file"
+          fi
+
+          rewrite_ubuntu_mirrors() {
+            local f="$1"
+            [[ -f "$f" ]] || return 0
+            sed -E -i \
+              -e 's#https?://(archive|security)\.ubuntu\.com/ubuntu/?#mirror+file:/etc/apt/ci-ubuntu-mirrors.txt#g' \
+              -e 's#https?://ports\.ubuntu\.com/ubuntu-ports/?#mirror+file:/etc/apt/ci-ubuntu-mirrors.txt#g' \
+              "$f"
+          }
+          rewrite_ubuntu_mirrors /etc/apt/sources.list
+          shopt -s nullglob
+          for f in /etc/apt/sources.list.d/*.list /etc/apt/sources.list.d/*.sources; do
+            rewrite_ubuntu_mirrors "$f"
+          done
+
+          echo "Ubuntu apt mirrors ($(dpkg --print-architecture)):"
+          cat "$mirrors_file"
+          grep -RInE 'URIs:|^deb ' /etc/apt/sources.list /etc/apt/sources.list.d 2>/dev/null || true
 
           apt-get update
           apt-get install -y ca-certificates curl gnupg git
@@ -496,11 +543,12 @@ jobs:
           echo "is_prerelease=$is_prerelease" >> "$GITHUB_OUTPUT"
 
       - name: Install build tools
+        timeout-minutes: 10
         shell: bash
         run: |
           set -eo pipefail
+          export DEBIAN_FRONTEND=noninteractive
 
-          apt-get update
           apt-get install -y \
             python3-rosdep \
             python3-colcon-core \
@@ -720,6 +768,7 @@ jobs:
           fi
 
       - name: Install workspace dependencies
+        timeout-minutes: 15
         shell: bash
         env:
           ROS_DISTRO: ${{ steps.meta.outputs.ros_distro }}
@@ -1194,10 +1243,51 @@ jobs:
           deb_file_version="${VERSION//~/.}"
           echo "deb_file=${DEB_PREFIX}_${deb_file_version}_${DEB_ARCH}.deb" >> "$GITHUB_OUTPUT"
 
-      - name: Install verification tools
+      - name: Configure apt and install verification tools
+        timeout-minutes: 8
         shell: bash
         run: |
           set -eo pipefail
+          export DEBIAN_FRONTEND=noninteractive
+
+          cat >/etc/apt/apt.conf.d/99-ci-acquire <<'EOF'
+          Acquire::Retries "1";
+          Acquire::http::Timeout "15";
+          Acquire::https::Timeout "15";
+          Acquire::Languages "none";
+          Acquire::IndexTargets::deb::DEP-11::DefaultEnabled "false";
+          EOF
+
+          mirrors_file=/etc/apt/ci-ubuntu-mirrors.txt
+          if [[ "$(dpkg --print-architecture)" == "arm64" ]]; then
+            printf '%s\n' \
+              $'http://azure.ports.ubuntu.com/ubuntu-ports/\tpriority:1' \
+              $'http://ports.ubuntu.com/ubuntu-ports/\tpriority:2' \
+              > "$mirrors_file"
+          else
+            printf '%s\n' \
+              $'http://azure.archive.ubuntu.com/ubuntu/\tpriority:1' \
+              $'http://archive.ubuntu.com/ubuntu/\tpriority:2' \
+              $'http://security.ubuntu.com/ubuntu/\tpriority:3' \
+              > "$mirrors_file"
+          fi
+
+          rewrite_ubuntu_mirrors() {
+            local f="$1"
+            [[ -f "$f" ]] || return 0
+            sed -E -i \
+              -e 's#https?://(archive|security)\.ubuntu\.com/ubuntu/?#mirror+file:/etc/apt/ci-ubuntu-mirrors.txt#g' \
+              -e 's#https?://ports\.ubuntu\.com/ubuntu-ports/?#mirror+file:/etc/apt/ci-ubuntu-mirrors.txt#g' \
+              "$f"
+          }
+          rewrite_ubuntu_mirrors /etc/apt/sources.list
+          shopt -s nullglob
+          for f in /etc/apt/sources.list.d/*.list /etc/apt/sources.list.d/*.sources; do
+            rewrite_ubuntu_mirrors "$f"
+          done
+
+          echo "Ubuntu apt mirrors ($(dpkg --print-architecture)):"
+          cat "$mirrors_file"
 
           apt-get update
           apt-get install -y ca-certificates curl cmake build-essential
@@ -1340,9 +1430,11 @@ jobs:
           ls -lh "$deps_dir"/*.deb
 
       - name: Install debs and verify package discovery
+        timeout-minutes: 10
         shell: bash
         run: |
           set -eo pipefail
+          export DEBIAN_FRONTEND=noninteractive
 
           ros_distro="${{ steps.meta.outputs.ros_distro }}"
 

--- a/.github/workflows/release-arms-ros2-control-deb.yml
+++ b/.github/workflows/release-arms-ros2-control-deb.yml
@@ -38,11 +38,11 @@ on:
         default: jazzy
         type: string
       ocs2_release_tag:
-        description: Release tag used to fetch the ocs2_ros2 bundle (optional; leave blank to use the latest release)
+        description: ocs2_ros2 release tag (v1.3.0, pre-release, or blank for latest formal / pre-release when this is a rolling build)
         required: false
         type: string
       common_release_tag:
-        description: Release tag used to fetch robot_descriptions common (optional; leave blank to use the latest release)
+        description: robot_descriptions common release tag (v*, pre-release, or blank)
         required: false
         type: string
 
@@ -423,16 +423,21 @@ jobs:
             local fallback_repo="$3"
             local dependency_name="$4"
 
-            if [[ -n "${requested_tag:-}" && "${requested_tag}" != [vV]* ]]; then
-              requested_tag="v${requested_tag}"
-            fi
-
             if [[ -n "${requested_tag:-}" ]]; then
-              if gh release view "$requested_tag" --repo "$primary_repo" --json tagName >/dev/null 2>&1 \
-                || gh release view "$requested_tag" --repo "$fallback_repo" --json tagName >/dev/null 2>&1; then
-                printf '%s\n' "$requested_tag"
-                return 0
+              local candidate
+              local -a candidates=("${requested_tag}")
+              # Version tags may omit the leading v (1.3.0 -> v1.3.0). Rolling names
+              # such as pre-release must stay unprefixed.
+              if [[ "${requested_tag}" != [vV]* ]]; then
+                candidates+=("v${requested_tag}")
               fi
+              for candidate in "${candidates[@]}"; do
+                if gh release view "$candidate" --repo "$primary_repo" --json tagName >/dev/null 2>&1 \
+                  || gh release view "$candidate" --repo "$fallback_repo" --json tagName >/dev/null 2>&1; then
+                  printf '%s\n' "$candidate"
+                  return 0
+                fi
+              done
               echo "Unable to find release tag ${requested_tag} for ${dependency_name} in ${primary_repo} or ${fallback_repo}." >&2
               exit 1
             fi
@@ -1020,16 +1025,21 @@ jobs:
             local fallback_repo="$3"
             local dependency_name="$4"
 
-            if [[ -n "${requested_tag:-}" && "${requested_tag}" != [vV]* ]]; then
-              requested_tag="v${requested_tag}"
-            fi
-
             if [[ -n "${requested_tag:-}" ]]; then
-              if gh release view "$requested_tag" --repo "$primary_repo" --json tagName >/dev/null 2>&1 \
-                || gh release view "$requested_tag" --repo "$fallback_repo" --json tagName >/dev/null 2>&1; then
-                printf '%s\n' "$requested_tag"
-                return 0
+              local candidate
+              local -a candidates=("${requested_tag}")
+              # Version tags may omit the leading v (1.3.0 -> v1.3.0). Rolling names
+              # such as pre-release must stay unprefixed.
+              if [[ "${requested_tag}" != [vV]* ]]; then
+                candidates+=("v${requested_tag}")
               fi
+              for candidate in "${candidates[@]}"; do
+                if gh release view "$candidate" --repo "$primary_repo" --json tagName >/dev/null 2>&1 \
+                  || gh release view "$candidate" --repo "$fallback_repo" --json tagName >/dev/null 2>&1; then
+                  printf '%s\n' "$candidate"
+                  return 0
+                fi
+              done
               echo "Unable to find release tag ${requested_tag} for ${dependency_name} in ${primary_repo} or ${fallback_repo}." >&2
               exit 1
             fi


### PR DESCRIPTION
## Summary
- Rewrite Canonical Ubuntu apt sources inside `ros:jazzy` containers to Azure-first mirror lists with short Acquire timeouts, so amd64 jobs stop stalling/failing on `archive.ubuntu.com`.
- Grant `actions: write` so `actions/cache` can save the rosdep sources cache (fixes `token has no writable scopes`).
- Drop the extra `apt-get update` in the build-tools step and add timeouts on apt/rosdep steps.

## Test plan
- [ ] Push is on `fix/cicd-azure`; this workflow does **not** run on PR open — trigger **workflow_dispatch** on this branch (or merge to main) to actually build debs.
- [ ] Confirm amd64 `Install GitHub CLI` / `Install build tools` / `rosdep` finish in about a minute, not 10–40 minutes, and no `Connection failed [archive.ubuntu.com]` errors.
- [ ] Confirm `Post Cache rosdep sources` no longer warns `cache write denied: token has no writable scopes`.
- [ ] Confirm arm64 jobs still succeed (ports mirrors should keep working via Azure-first + fallback).


Made with [Cursor](https://cursor.com)